### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/doublewordai/outlet-postgres/compare/v0.1.1...v0.1.2) - 2025-08-28
+
+### Added
+
+- enhance README with performance highlights
+
 ## [0.1.1](https://github.com/doublewordai/outlet-postgres/compare/v0.1.0...v0.1.1) - 2025-08-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "outlet-postgres"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "outlet-postgres"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "PostgreSQL logging handler for outlet HTTP request/response middleware"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `outlet-postgres`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/doublewordai/outlet-postgres/compare/v0.1.1...v0.1.2) - 2025-08-28

### Added

- enhance README with performance highlights
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).