### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/doublewordai/outlet-postgres/compare/v0.1.2...v0.2.0) - 2025-08-29
+
+### Added
+
+- path filtering for logged responses
+- add custom serializers, move `migrator` into standalone function
+
 ## [0.1.2](https://github.com/doublewordai/outlet-postgres/compare/v0.1.1...v0.1.2) - 2025-08-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "outlet-postgres"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "outlet-postgres"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 description = "PostgreSQL logging handler for outlet HTTP request/response middleware"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `outlet-postgres`: 0.1.2 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `outlet-postgres` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/inherent_method_missing.ron

Failed in:
  PostgresHandler::migrator, previously in file /tmp/.tmpt6851A/outlet-postgres/src/lib.rs:257
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/doublewordai/outlet-postgres/compare/v0.1.2...v0.2.0) - 2025-08-29

### Added

- path filtering for logged responses
- add custom serializers, move `migrator` into standalone function
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).