### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/doublewordai/outlet-postgres/compare/v0.2.0...v0.3.0) - 2025-09-01
+
+### Fixed
+
+- path filtering didnt take into account hosts
+- add instance id so that ids are unique across restarts
+
 ## [0.2.0](https://github.com/doublewordai/outlet-postgres/compare/v0.1.2...v0.2.0) - 2025-08-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "outlet-postgres"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "outlet-postgres"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "PostgreSQL logging handler for outlet HTTP request/response middleware"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `outlet-postgres`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `outlet-postgres` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field RequestFilter.instance_id in /tmp/.tmpsFMvHQ/outlet-postgres/src/repository.rs:45
  field RequestFilter.instance_id in /tmp/.tmpsFMvHQ/outlet-postgres/src/repository.rs:45
  field HttpResponse.instance_id in /tmp/.tmpsFMvHQ/outlet-postgres/src/repository.rs:27
  field HttpResponse.instance_id in /tmp/.tmpsFMvHQ/outlet-postgres/src/repository.rs:27
  field HttpRequest.instance_id in /tmp/.tmpsFMvHQ/outlet-postgres/src/repository.rs:14
  field HttpRequest.instance_id in /tmp/.tmpsFMvHQ/outlet-postgres/src/repository.rs:14
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/doublewordai/outlet-postgres/compare/v0.2.0...v0.3.0) - 2025-09-01

### Fixed

- path filtering didnt take into account hosts
- add instance id so that ids are unique across restarts
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).