### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/doublewordai/outlet-postgres/compare/v0.3.0...v0.3.1) - 2025-09-02
+
+### Other
+
+- Merge branch 'main' of https://github.com/doublewordai/outlet-postgres
+- Update API to match outlet v0.3.0
+- Update outlet dependency to v0.3.0
+
 ## [0.3.0](https://github.com/doublewordai/outlet-postgres/compare/v0.2.0...v0.3.0) - 2025-09-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "outlet-postgres"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "outlet-postgres"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "PostgreSQL logging handler for outlet HTTP request/response middleware"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `outlet-postgres`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/doublewordai/outlet-postgres/compare/v0.3.0...v0.3.1) - 2025-09-02

### Other

- Merge branch 'main' of https://github.com/doublewordai/outlet-postgres
- Update API to match outlet v0.3.0
- Update outlet dependency to v0.3.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).