### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/doublewordai/outlet-postgres/compare/v0.3.1...v0.4.0) - 2025-09-25
+
+### Added
+
+- split off time-to-first-byte from duration
+
+### Fixed
+
+- clippy
+
+### Other
+
+- Merge pull request #7 from doublewordai/time-to-first-byte
+
 ## [0.3.1](https://github.com/doublewordai/outlet-postgres/compare/v0.3.0...v0.3.1) - 2025-09-02
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,7 +1072,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "outlet"
-version = "0.2.0"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f8c1d1cfe65872393f307fc8e34313cc6030bafa4f1209a87d6ae6bb180de8b"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1095,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "outlet-postgres"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "outlet-postgres"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 description = "PostgreSQL logging handler for outlet HTTP request/response middleware"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `outlet-postgres`: 0.3.1 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `outlet-postgres` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field RequestFilter.min_duration_to_first_byte_ms in /tmp/.tmp58nHnV/outlet-postgres/src/repository.rs:57
  field RequestFilter.max_duration_to_first_byte_ms in /tmp/.tmp58nHnV/outlet-postgres/src/repository.rs:58
  field RequestFilter.min_duration_to_first_byte_ms in /tmp/.tmp58nHnV/outlet-postgres/src/repository.rs:57
  field RequestFilter.max_duration_to_first_byte_ms in /tmp/.tmp58nHnV/outlet-postgres/src/repository.rs:58
  field HttpResponse.duration_to_first_byte_ms in /tmp/.tmp58nHnV/outlet-postgres/src/repository.rs:33
  field HttpResponse.duration_to_first_byte_ms in /tmp/.tmp58nHnV/outlet-postgres/src/repository.rs:33
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/doublewordai/outlet-postgres/compare/v0.3.1...v0.4.0) - 2025-09-25

### Added

- split off time-to-first-byte from duration

### Fixed

- clippy

### Other

- Merge pull request #7 from doublewordai/time-to-first-byte
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).