### PR TITLE
chore: release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/doublewordai/outlet-postgres/compare/v0.4.2...v0.4.3) - 2025-11-11
+
+### Fixed
+
+- quieter logs and log lag
+
+### Other
+
+- update readme
+- Merge branch 'main' of https://github.com/doublewordai/outlet-postgres
+
 ## [0.4.2](https://github.com/doublewordai/outlet-postgres/compare/v0.4.1...v0.4.2) - 2025-11-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,9 +1072,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "outlet"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980a1e9adbbfe60d8cc3bab0947b10c6710281a240a1c3d0d17a153be1b0d3f8"
+checksum = "b71c5ba1c445cf62752a81ac699c113109bbb4bfae9f7d01c30e664537ec59d9"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "outlet-postgres"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "outlet-postgres"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 description = "PostgreSQL logging handler for outlet HTTP request/response middleware"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `outlet-postgres`: 0.4.2 -> 0.4.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.3](https://github.com/doublewordai/outlet-postgres/compare/v0.4.2...v0.4.3) - 2025-11-11

### Fixed

- quieter logs and log lag

### Other

- update readme
- Merge branch 'main' of https://github.com/doublewordai/outlet-postgres
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).