### PR TITLE
chore: release v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4](https://github.com/doublewordai/outlet-postgres/compare/v0.4.3...v0.4.4) - 2026-01-07
+
+### Added
+
+- add write duration metrics
+
+### Other
+
+- *(deps)* update actions/checkout action to v6 ([#27](https://github.com/doublewordai/outlet-postgres/pull/27))
+- *(deps)* update rust crate bytes to v1.11.0 ([#23](https://github.com/doublewordai/outlet-postgres/pull/23))
+- *(deps)* update rust crate thiserror to v2.0.17 ([#22](https://github.com/doublewordai/outlet-postgres/pull/22))
+- *(deps)* update tokio-tracing monorepo ([#29](https://github.com/doublewordai/outlet-postgres/pull/29))
+- *(deps)* update rust crate uuid to v1.19.0 ([#30](https://github.com/doublewordai/outlet-postgres/pull/30))
+- *(deps)* update rust crate chrono to v0.4.42 ([#19](https://github.com/doublewordai/outlet-postgres/pull/19))
+- *(deps)* update mozilla-actions/sccache-action action to v0.0.9 ([#15](https://github.com/doublewordai/outlet-postgres/pull/15))
+- *(deps)* update rust crate axum to v0.8.7 ([#17](https://github.com/doublewordai/outlet-postgres/pull/17))
+- Add renovate.json ([#14](https://github.com/doublewordai/outlet-postgres/pull/14))
+
 ## [0.4.3](https://github.com/doublewordai/outlet-postgres/compare/v0.4.2...v0.4.3) - 2025-11-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "outlet-postgres"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "outlet-postgres"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 description = "PostgreSQL logging handler for outlet HTTP request/response middleware"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `outlet-postgres`: 0.4.3 -> 0.4.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.4](https://github.com/doublewordai/outlet-postgres/compare/v0.4.3...v0.4.4) - 2026-01-07

### Added

- add write duration metrics

### Other

- *(deps)* update actions/checkout action to v6 ([#27](https://github.com/doublewordai/outlet-postgres/pull/27))
- *(deps)* update rust crate bytes to v1.11.0 ([#23](https://github.com/doublewordai/outlet-postgres/pull/23))
- *(deps)* update rust crate thiserror to v2.0.17 ([#22](https://github.com/doublewordai/outlet-postgres/pull/22))
- *(deps)* update tokio-tracing monorepo ([#29](https://github.com/doublewordai/outlet-postgres/pull/29))
- *(deps)* update rust crate uuid to v1.19.0 ([#30](https://github.com/doublewordai/outlet-postgres/pull/30))
- *(deps)* update rust crate chrono to v0.4.42 ([#19](https://github.com/doublewordai/outlet-postgres/pull/19))
- *(deps)* update mozilla-actions/sccache-action action to v0.0.9 ([#15](https://github.com/doublewordai/outlet-postgres/pull/15))
- *(deps)* update rust crate axum to v0.8.7 ([#17](https://github.com/doublewordai/outlet-postgres/pull/17))
- Add renovate.json ([#14](https://github.com/doublewordai/outlet-postgres/pull/14))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).