### PR TITLE
fix(repository): set where_added for ttfb filter

### DIFF
--- a/src/repository.rs
+++ b/src/repository.rs
@@ -211,6 +211,7 @@ impl RequestFilter {
                 query.push(" AND ");
             } else {
                 query.push(" WHERE ");
+                where_added = true;
             }
             query.push("res.duration_to_first_byte_ms <= ");
             query.push_bind(max_duration_to_first_byte);


### PR DESCRIPTION
## Summary
- set `where_added = true` in the `max_duration_to_first_byte_ms` filter branch when it introduces the first WHERE clause
- preserve the existing query builder pattern so later filters append with AND

## Testing
- DATABASE_URL=postgresql:///postgres cargo test