### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/doublewordai/outlet-postgres/compare/v0.5.0...v0.5.1) - 2026-03-12
+
+### Added
+
+- bulk INSERT via UNNEST for batch dispatch ([#65](https://github.com/doublewordai/outlet-postgres/pull/65))
+
+### Other
+
+- release v0.5.0 ([#62](https://github.com/doublewordai/outlet-postgres/pull/62))
+
 ## [0.5.0](https://github.com/doublewordai/outlet-postgres/compare/v0.4.8...v0.5.0) - 2026-03-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "outlet"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "912fa05ac7da27693b4ed09ddd23ab5500709ab0ccb8cfa4fe555ddcfed620ae"
+checksum = "bc2267a2dcdc06dc06dc701bd768ee9b6ca9f12567094477898c1d8108e9b407"
 dependencies = [
  "anyhow",
  "axum",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "outlet-postgres"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "axum",
  "base64",
@@ -1784,7 +1784,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "outlet-postgres"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "PostgreSQL logging handler for outlet HTTP request/response middleware"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `outlet-postgres`: 0.5.0 -> 0.5.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.1](https://github.com/doublewordai/outlet-postgres/compare/v0.5.0...v0.5.1) - 2026-03-12

### Added

- bulk INSERT via UNNEST for batch dispatch ([#65](https://github.com/doublewordai/outlet-postgres/pull/65))

### Other

- release v0.5.0 ([#62](https://github.com/doublewordai/outlet-postgres/pull/62))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).