### PR TITLE
fix(deps): bump rand, rsa, rustls-webpki to clear 6 Oneleet findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,11 +952,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
- "byteorder",
  "lazy_static",
  "libm",
  "num-integer",
@@ -1220,9 +1219,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -1310,9 +1309,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.8"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
  "const-oid",
  "digest",
@@ -1353,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
Single `cargo update` bumps three transitive deps to their patched versions, closing 6 Oneleet findings against this repo's `Cargo.lock`.

| Was | Now | Findings closed |
|---|---|---|
| `rand` 0.8.5 | 0.8.6 | GHSA-cq8v-f236-94qc (`IterMut` Stacked Borrows / sound logger reseeding) |
| `rsa` 0.9.8 | 0.9.10 | CVE-2026-21895 (panic when constructing RSA private key from `p=1`) |
| `rustls-webpki` 0.103.4 | 0.103.13 | GHSA-82j2-j2ch-gfr8 (CRL `BIT STRING` panic DoS), GHSA-pwjx-qhcg-rvj4 (CRL distributionPoint matching), GHSA-xgp8-3hg3-c2mh (wildcard name constraints), GHSA-965h-392x-2mh5 (URI name constraints) |

`num-bigint-dig` is dragged from 0.8.4 → 0.8.6 by the rsa bump.

## Notes
- All three packages are transitive; no `Cargo.toml` changes required.
- This repo was the last unresolved entry on these findings — the same advisories on other Doubleword repos are already marked `Resolved` upstream.

## Test plan
- [x] `cargo build` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --lib` (unit tests) pass locally
- [ ] CI runs the full `#[sqlx::test]` integration suite against Postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)