### PR TITLE
feat!: adopt outlet 0.9 response extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "outlet"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc2267a2dcdc06dc06dc701bd768ee9b6ca9f12567094477898c1d8108e9b407"
+checksum = "105438f773ecf29bc835501af0d89220f6ae3f7a98a3da14ad58cf2c45d3fdb4"
 dependencies = [
  "anyhow",
  "axum",
@@ -1953,14 +1953,15 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
  "bitflags",
  "bytes",
  "http",
  "http-body",
+ "percent-encoding",
  "pin-project-lite",
  "tower-layer",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["web-programming", "database"]
 authors = ["fergus.finn@doubleword.ai"]
 
 [dependencies]
-outlet = "0.8.0"
+outlet = "0.9"
 sqlx-pool-router = { version = "0.2.0" }
 tokio = { version = "1.0", features = ["full"] }
 sqlx = { version = "0.8", features = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -791,6 +791,7 @@ mod tests {
             duration_to_first_byte: Duration::from_millis(100),
             duration: Duration::from_millis(150),
             correlation_id: 0,
+            extensions: Default::default(),
         }
     }
 
@@ -1008,6 +1009,7 @@ mod tests {
                 timestamp: SystemTime::now(),
                 duration_to_first_byte: Duration::from_millis(duration_ms / 2),
                 duration: Duration::from_millis(duration_ms),
+                extensions: Default::default(),
             };
 
             handler.handle_request(request_data.clone()).await;


### PR DESCRIPTION
Bumps the outlet dependency for the new `ResponseData.extensions` field (typed per-request annotations from inner services — e.g. routing attribution for billing). No handler logic changes; only test constructors gain the field.

**Blocked on the outlet release** containing the extensions change — CI cannot resolve `outlet = "0.9"` until it's published. Validated locally against that branch via a path patch: full suite green (33 tests).