### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/doublewordai/outlet-postgres/compare/v0.5.1...v0.6.0) - 2026-07-17
+
+### Added
+
+- [**breaking**] adopt outlet 0.9 response extensions ([#80](https://github.com/doublewordai/outlet-postgres/pull/80))
+
 ## [0.5.1](https://github.com/doublewordai/outlet-postgres/compare/v0.5.0...v0.5.1) - 2026-03-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "outlet-postgres"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "outlet-postgres"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 description = "PostgreSQL logging handler for outlet HTTP request/response middleware"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `outlet-postgres`: 0.5.1 -> 0.6.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.0](https://github.com/doublewordai/outlet-postgres/compare/v0.5.1...v0.6.0) - 2026-07-17

### Added

- [**breaking**] adopt outlet 0.9 response extensions ([#80](https://github.com/doublewordai/outlet-postgres/pull/80))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).