### PR TITLE
chore: use outlet graceful drain support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,8 +1019,7 @@ dependencies = [
 [[package]]
 name = "outlet"
 version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "105438f773ecf29bc835501af0d89220f6ae3f7a98a3da14ad58cf2c45d3fdb4"
+source = "git+https://github.com/doublewordai/outlet?rev=6206a0bedc0c9a5d1ad77b837ec334642d06eea8#6206a0bedc0c9a5d1ad77b837ec334642d06eea8"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["web-programming", "database"]
 authors = ["fergus.finn@doubleword.ai"]
 
 [dependencies]
-outlet = "0.9"
+outlet = { git = "https://github.com/doublewordai/outlet", rev = "6206a0bedc0c9a5d1ad77b837ec334642d06eea8" }
 sqlx-pool-router = { version = "0.2.0" }
 tokio = { version = "1.0", features = ["full"] }
 sqlx = { version = "0.8", features = [


### PR DESCRIPTION
## Summary
- pin Outlet to the graceful-drain implementation from doublewordai/outlet#99
- keep `PostgresHandler` on the same `RequestHandler` trait instance as downstream consumers

## Dependency
- Requires doublewordai/outlet#99

## Verification
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (33 unit/integration tests and 5 doc tests passed)