### PR TITLE
feat: add privacy-aware request capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- add configurable header allowlists and opaque subject attribution for privacy-aware capture
+
 ## [0.6.0](https://github.com/doublewordai/outlet-postgres/compare/v0.5.1...v0.6.0) - 2026-07-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Basic usage:
 
 ```rust
 use outlet::{RequestLoggerLayer, RequestLoggerConfig};
-use outlet_postgres::PostgresHandler;
+use outlet_postgres::{CapturePolicy, PostgresHandler};
 use axum::{routing::get, Router};
 use tower::ServiceBuilder;
 
@@ -35,7 +35,11 @@ async fn hello() -> &'static str {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let database_url = "postgresql://user:password@localhost/dbname";
-    let handler = PostgresHandler::new(database_url).await?;
+    let capture_policy = CapturePolicy::allow_headers(["content-type", "user-agent"])?
+        .with_subject_header("x-application-subject")?;
+    let handler = PostgresHandler::new(database_url)
+        .await?
+        .with_capture_policy(capture_policy);
     let layer = RequestLoggerLayer::new(RequestLoggerConfig::default(), handler);
 
     let app = Router::new()
@@ -60,6 +64,7 @@ The handler automatically creates two tables:
 - `method` - HTTP method (GET, POST, etc.)
 - `uri` - Full request URI
 - `headers` - Request headers as JSONB
+- `subject_id` - Optional opaque application subject for targeted lifecycle operations
 - `body` - Request body as JSONB (optional)
 - `body_parsed` - Whether the body was parsed as the supplied JSON-serde type (default `serde_json::Value`) or not. If not, the `body` field is the base64-encoded binary data.
 - `created_at` - When the record was inserted
@@ -71,6 +76,7 @@ The handler automatically creates two tables:
 - `timestamp` - When the response was sent
 - `status_code` - HTTP status code
 - `headers` - Response headers as JSONB
+- `subject_id` - Optional opaque application subject copied from the request
 - `body` - Response body as JSONB (optional)
 - `body_parsed` - Whether the body was parsed as the supplied JSON-serde type (default `serde_json::Value`) or not. If not, the `body` field is the base64-encoded binary data.
 - `duration_ms` - Request processing time in milliseconds
@@ -78,7 +84,7 @@ The handler automatically creates two tables:
 
 ## Configuration
 
-You can control what data is captured using `RequestLoggerConfig`:
+Use `RequestLoggerConfig` to control body capture in the middleware:
 
 ```rust
 use outlet::RequestLoggerConfig;
@@ -98,6 +104,34 @@ let config = RequestLoggerConfig {
     capture_response_body: false,
 };
 ```
+
+Use `CapturePolicy` to limit which headers reach serializers and PostgreSQL:
+
+```rust
+use outlet_postgres::CapturePolicy;
+
+let capture_policy = CapturePolicy::allow_headers([
+    "content-type",
+    "user-agent",
+])?
+.with_subject_header("x-application-subject")?;
+
+let handler = PostgresHandler::new(database_url)
+    .await?
+    .with_capture_policy(capture_policy);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+Prefer an allowlist for sensitive traffic. Header matching is case-insensitive,
+and retained names are stored in lowercase. The optional subject value must be
+an opaque identifier. Its carrier header is removed unless it is also present
+in the request allowlist. The same sanitized data is supplied to custom body
+serializers, preventing them from persisting filtered headers inside `body`.
+
+`CapturePolicy::all()` is the backwards-compatible default. The subject columns
+are nullable, and the migration intentionally does not create subject indexes.
+Existing installations can add suitable indexes separately using their normal
+online migration process.
 
 ## Example Queries
 

--- a/examples/typed_usage.rs
+++ b/examples/typed_usage.rs
@@ -5,7 +5,7 @@ use axum::{
     Json, Router,
 };
 use outlet::{RequestLoggerConfig, RequestLoggerLayer};
-use outlet_postgres::{PostgresHandler, RequestFilter, RequestRepository};
+use outlet_postgres::{CapturePolicy, PostgresHandler, RequestFilter, RequestRepository};
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use tower::ServiceBuilder;
@@ -311,8 +311,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create handler with typed request and response bodies
     // ApiResponse uses serde untagged enum to handle both CreateUserResponse and ErrorResponse
-    let handler =
-        PostgresHandler::<PgPool, CreateUserRequest, ApiResponse>::new(&database_url).await?;
+    let capture_policy = CapturePolicy::allow_headers(["content-type", "user-agent"])?
+        .with_subject_header("x-application-subject")?;
+    let handler = PostgresHandler::<PgPool, CreateUserRequest, ApiResponse>::new(&database_url)
+        .await?
+        .with_capture_policy(capture_policy);
 
     // Get the repository from the handler and store it in app state
     let repository = handler.repository();

--- a/migrations/20260813000001_add_capture_subject.sql
+++ b/migrations/20260813000001_add_capture_subject.sql
@@ -1,0 +1,5 @@
+-- Opaque application subject used for targeted lifecycle operations.
+-- Indexes are intentionally left to operators because existing table sizes and
+-- online index requirements vary between deployments.
+ALTER TABLE http_requests ADD COLUMN subject_id TEXT;
+ALTER TABLE http_responses ADD COLUMN subject_id TEXT;

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1,0 +1,392 @@
+use http::header::{HeaderName, InvalidHeaderName};
+use outlet::{RequestData, ResponseData};
+use std::collections::{HashMap, HashSet};
+
+#[derive(Clone, Debug)]
+enum HeaderSelection {
+    All,
+    Allow(HashSet<HeaderName>),
+}
+
+impl HeaderSelection {
+    fn allow<I, S>(headers: I) -> Result<Self, InvalidHeaderName>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        headers
+            .into_iter()
+            .map(|name| HeaderName::from_bytes(name.as_ref().as_bytes()))
+            .collect::<Result<HashSet<_>, _>>()
+            .map(Self::Allow)
+    }
+
+    fn apply(&self, headers: &mut HashMap<String, Vec<bytes::Bytes>>) {
+        let mut entries = std::mem::take(headers).into_iter().collect::<Vec<_>>();
+        entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+        for (name, values) in entries {
+            let canonical_name = match HeaderName::from_bytes(name.as_bytes()) {
+                Ok(canonical_name) => canonical_name,
+                Err(_) if matches!(self, Self::All) => {
+                    headers.entry(name).or_default().extend(values);
+                    continue;
+                }
+                Err(_) => continue,
+            };
+            let retained = match self {
+                Self::All => true,
+                Self::Allow(allowed) => allowed.contains(&canonical_name),
+            };
+            if retained {
+                headers
+                    .entry(canonical_name.as_str().to_owned())
+                    .or_default()
+                    .extend(values);
+            }
+        }
+    }
+
+    fn explicitly_allows(&self, header: &HeaderName) -> bool {
+        matches!(self, Self::Allow(allowed) if allowed.contains(header))
+    }
+}
+
+/// Controls which HTTP headers are made available to persistent capture.
+///
+/// The default preserves all headers for backwards compatibility. Applications
+/// handling sensitive traffic should configure explicit request and response
+/// allowlists.
+#[derive(Clone, Debug)]
+pub struct CapturePolicy {
+    request_headers: HeaderSelection,
+    response_headers: HeaderSelection,
+    subject_header: Option<HeaderName>,
+}
+
+impl Default for CapturePolicy {
+    fn default() -> Self {
+        Self::all()
+    }
+}
+
+impl CapturePolicy {
+    /// Preserve all request and response headers.
+    pub fn all() -> Self {
+        Self {
+            request_headers: HeaderSelection::All,
+            response_headers: HeaderSelection::All,
+            subject_header: None,
+        }
+    }
+
+    /// Apply the same header allowlist to requests and responses.
+    pub fn allow_headers<I, S>(headers: I) -> Result<Self, InvalidHeaderName>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let selection = HeaderSelection::allow(headers)?;
+        Ok(Self {
+            request_headers: selection.clone(),
+            response_headers: selection,
+            subject_header: None,
+        })
+    }
+
+    /// Replace the request header allowlist.
+    pub fn with_request_headers<I, S>(mut self, headers: I) -> Result<Self, InvalidHeaderName>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.request_headers = HeaderSelection::allow(headers)?;
+        Ok(self)
+    }
+
+    /// Replace the response header allowlist.
+    pub fn with_response_headers<I, S>(mut self, headers: I) -> Result<Self, InvalidHeaderName>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.response_headers = HeaderSelection::allow(headers)?;
+        Ok(self)
+    }
+
+    /// Extract an opaque subject identifier from a request header before
+    /// applying the request allowlist.
+    pub fn with_subject_header(
+        mut self,
+        header: impl AsRef<str>,
+    ) -> Result<Self, InvalidHeaderName> {
+        self.subject_header = Some(HeaderName::from_bytes(header.as_ref().as_bytes())?);
+        Ok(self)
+    }
+
+    pub(crate) fn prepare_request(&self, mut data: RequestData) -> PreparedRequest {
+        let subject_id = self.subject_id(&data);
+        self.remove_unlisted_subject_carrier(&mut data.headers);
+        self.request_headers.apply(&mut data.headers);
+        PreparedRequest { data, subject_id }
+    }
+
+    pub(crate) fn prepare_response(
+        &self,
+        mut request: RequestData,
+        mut response: ResponseData,
+    ) -> PreparedResponse {
+        let subject_id = self.subject_id(&request);
+        self.remove_unlisted_subject_carrier(&mut request.headers);
+        self.request_headers.apply(&mut request.headers);
+        self.response_headers.apply(&mut response.headers);
+        PreparedResponse {
+            request,
+            response,
+            subject_id,
+        }
+    }
+
+    fn subject_id(&self, request: &RequestData) -> Option<String> {
+        let subject_header = self.subject_header.as_ref()?;
+        let mut values = request
+            .headers
+            .iter()
+            .filter(|(name, _)| name.eq_ignore_ascii_case(subject_header.as_str()))
+            .flat_map(|(_, values)| values.iter());
+        let value = values.next()?;
+        if values.next().is_some() || value.is_empty() {
+            return None;
+        }
+        std::str::from_utf8(value).ok().map(str::to_owned)
+    }
+
+    fn remove_unlisted_subject_carrier(&self, headers: &mut HashMap<String, Vec<bytes::Bytes>>) {
+        let Some(subject_header) = self.subject_header.as_ref() else {
+            return;
+        };
+        if !self.request_headers.explicitly_allows(subject_header) {
+            headers.retain(|name, _| !name.eq_ignore_ascii_case(subject_header.as_str()));
+        }
+    }
+}
+
+pub(crate) struct PreparedRequest {
+    pub(crate) data: RequestData,
+    pub(crate) subject_id: Option<String>,
+}
+
+pub(crate) struct PreparedResponse {
+    pub(crate) request: RequestData,
+    pub(crate) response: ResponseData,
+    pub(crate) subject_id: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use outlet::{RequestData, ResponseData};
+    use std::collections::HashMap;
+    use std::time::{Duration, SystemTime};
+
+    fn request(headers: impl IntoIterator<Item = (&'static str, Vec<Bytes>)>) -> RequestData {
+        RequestData {
+            correlation_id: 7,
+            timestamp: SystemTime::UNIX_EPOCH,
+            method: http::Method::POST,
+            uri: http::Uri::from_static("/requests"),
+            headers: headers
+                .into_iter()
+                .map(|(name, values)| (name.to_owned(), values))
+                .collect::<HashMap<_, _>>(),
+            body: Some(Bytes::from_static(br#"{"prompt":"hello"}"#)),
+            trace_id: Some("trace-id".to_owned()),
+            span_id: Some("span-id".to_owned()),
+        }
+    }
+
+    fn response(headers: impl IntoIterator<Item = (&'static str, Vec<Bytes>)>) -> ResponseData {
+        ResponseData {
+            correlation_id: 7,
+            timestamp: SystemTime::UNIX_EPOCH,
+            status: http::StatusCode::OK,
+            headers: headers
+                .into_iter()
+                .map(|(name, values)| (name.to_owned(), values))
+                .collect::<HashMap<_, _>>(),
+            body: Some(Bytes::from_static(br#"{"result":"hello"}"#)),
+            duration_to_first_byte: Duration::from_millis(10),
+            duration: Duration::from_millis(20),
+            extensions: Default::default(),
+        }
+    }
+
+    #[test]
+    fn allowlist_is_case_insensitive_and_canonicalises_persisted_names() {
+        let policy = CapturePolicy::allow_headers(["Content-Type", "X-Request-ID"])
+            .expect("valid header names");
+        let prepared = policy.prepare_request(request([
+            (
+                "CONTENT-TYPE",
+                vec![Bytes::from_static(b"application/json")],
+            ),
+            ("x-request-id", vec![Bytes::from_static(b"req-1")]),
+            ("authorization", vec![Bytes::from_static(b"Bearer secret")]),
+        ]));
+
+        assert_eq!(prepared.data.headers.len(), 2);
+        assert_eq!(
+            prepared.data.headers["content-type"][0],
+            Bytes::from_static(b"application/json")
+        );
+        assert_eq!(
+            prepared.data.headers["x-request-id"][0],
+            Bytes::from_static(b"req-1")
+        );
+        assert!(!prepared.data.headers.contains_key("authorization"));
+    }
+
+    #[test]
+    fn default_preserves_all_values_with_canonical_names_and_no_subject() {
+        let prepared = CapturePolicy::all().prepare_request(request([
+            ("x-request-id", vec![Bytes::from_static(b"lower")]),
+            ("X-Request-ID", vec![Bytes::from_static(b"upper")]),
+            (
+                "Content-Type",
+                vec![Bytes::from_static(b"application/json")],
+            ),
+        ]));
+
+        assert_eq!(prepared.subject_id, None);
+        assert_eq!(prepared.data.headers.len(), 2);
+        assert_eq!(
+            prepared.data.headers["x-request-id"],
+            vec![Bytes::from_static(b"upper"), Bytes::from_static(b"lower")]
+        );
+        assert_eq!(
+            prepared.data.headers["content-type"],
+            vec![Bytes::from_static(b"application/json")]
+        );
+    }
+
+    #[test]
+    fn subject_is_extracted_before_its_carrier_is_removed() {
+        let policy = CapturePolicy::allow_headers(["content-type"])
+            .unwrap()
+            .with_subject_header("x-capture-subject")
+            .unwrap();
+        let prepared = policy.prepare_request(request([
+            (
+                "x-capture-subject",
+                vec![Bytes::from_static(b"18c27488-7cf8-4cca-a90b-2cb472a9979f")],
+            ),
+            (
+                "content-type",
+                vec![Bytes::from_static(b"application/json")],
+            ),
+        ]));
+
+        assert_eq!(
+            prepared.subject_id.as_deref(),
+            Some("18c27488-7cf8-4cca-a90b-2cb472a9979f")
+        );
+        assert!(!prepared.data.headers.contains_key("x-capture-subject"));
+    }
+
+    #[test]
+    fn subject_carrier_requires_explicit_allowlisting() {
+        let policy = CapturePolicy::all()
+            .with_subject_header("x-capture-subject")
+            .unwrap();
+        let prepared = policy.prepare_request(request([(
+            "x-capture-subject",
+            vec![Bytes::from_static(b"subject-1")],
+        )]));
+
+        assert_eq!(prepared.subject_id.as_deref(), Some("subject-1"));
+        assert!(!prepared.data.headers.contains_key("x-capture-subject"));
+
+        let explicitly_allowed = CapturePolicy::allow_headers(["x-capture-subject"])
+            .unwrap()
+            .with_subject_header("x-capture-subject")
+            .unwrap()
+            .prepare_request(request([(
+                "x-capture-subject",
+                vec![Bytes::from_static(b"subject-1")],
+            )]));
+        assert!(explicitly_allowed
+            .data
+            .headers
+            .contains_key("x-capture-subject"));
+    }
+
+    #[test]
+    fn invalid_or_empty_subject_is_not_persisted() {
+        let policy = CapturePolicy::all()
+            .with_subject_header("x-capture-subject")
+            .unwrap();
+
+        for value in [Bytes::new(), Bytes::from_static(b"\xff")] {
+            let prepared = policy.prepare_request(request([("x-capture-subject", vec![value])]));
+            assert_eq!(prepared.subject_id, None);
+        }
+    }
+
+    #[test]
+    fn ambiguous_multi_value_subject_is_not_persisted() {
+        let policy = CapturePolicy::all()
+            .with_subject_header("x-capture-subject")
+            .unwrap();
+        let prepared = policy.prepare_request(request([(
+            "x-capture-subject",
+            vec![
+                Bytes::from_static(b"subject-1"),
+                Bytes::from_static(b"subject-2"),
+            ],
+        )]));
+
+        assert_eq!(prepared.subject_id, None);
+    }
+
+    #[test]
+    fn canonical_name_collisions_preserve_all_values_deterministically() {
+        let policy = CapturePolicy::allow_headers(["x-request-id"]).unwrap();
+        let prepared = policy.prepare_request(request([
+            ("x-request-id", vec![Bytes::from_static(b"lower")]),
+            ("X-Request-ID", vec![Bytes::from_static(b"upper")]),
+        ]));
+
+        assert_eq!(
+            prepared.data.headers["x-request-id"],
+            vec![Bytes::from_static(b"upper"), Bytes::from_static(b"lower")]
+        );
+    }
+
+    #[test]
+    fn request_and_response_allowlists_are_independent() {
+        let policy = CapturePolicy::all()
+            .with_request_headers(["content-type"])
+            .unwrap()
+            .with_response_headers(["cache-control"])
+            .unwrap();
+        let prepared = policy.prepare_response(
+            request([
+                (
+                    "content-type",
+                    vec![Bytes::from_static(b"application/json")],
+                ),
+                ("authorization", vec![Bytes::from_static(b"secret")]),
+            ]),
+            response([
+                ("cache-control", vec![Bytes::from_static(b"no-store")]),
+                ("set-cookie", vec![Bytes::from_static(b"secret")]),
+            ]),
+        );
+
+        assert_eq!(prepared.request.headers.len(), 1);
+        assert_eq!(prepared.response.headers.len(), 1);
+        assert!(prepared.request.headers.contains_key("content-type"));
+        assert!(prepared.response.headers.contains_key("cache-control"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,8 +93,11 @@ use std::time::{Instant, SystemTime};
 use tracing::{debug, error, instrument, warn};
 use uuid::Uuid;
 
+mod capture;
 pub mod error;
 pub mod repository;
+pub use capture::CapturePolicy;
+use capture::{PreparedRequest, PreparedResponse};
 pub use error::PostgresHandlerError;
 pub use repository::{
     HttpRequest, HttpResponse, RequestFilter, RequestRepository, RequestResponsePair,
@@ -169,6 +172,7 @@ where
     request_serializer: RequestSerializer<TReq>,
     response_serializer: ResponseSerializer<TRes>,
     instance_id: Uuid,
+    capture_policy: CapturePolicy,
 }
 
 impl<P, TReq, TRes> PostgresHandler<P, TReq, TRes>
@@ -242,6 +246,13 @@ where
         self
     }
 
+    /// Configure the headers and opaque subject identifier made available to
+    /// serializers and persistent storage.
+    pub fn with_capture_policy(mut self, policy: CapturePolicy) -> Self {
+        self.capture_policy = policy;
+        self
+    }
+
     /// Create a PostgreSQL handler from a pool provider.
     ///
     /// Use this if you want to use a custom pool provider implementation
@@ -287,6 +298,7 @@ where
             request_serializer: Self::default_request_serializer(),
             response_serializer: Self::default_response_serializer(),
             instance_id: Uuid::new_v4(),
+            capture_policy: CapturePolicy::default(),
         })
     }
 
@@ -414,6 +426,7 @@ where
             request_serializer: Self::default_request_serializer(),
             response_serializer: Self::default_response_serializer(),
             instance_id: Uuid::new_v4(),
+            capture_policy: CapturePolicy::default(),
         })
     }
 
@@ -464,6 +477,7 @@ where
 {
     #[instrument(name = "outlet.handle_request", skip(self, data), fields(correlation_id = %data.correlation_id))]
     async fn handle_request(&self, data: RequestData) {
+        let PreparedRequest { data, subject_id } = self.capture_policy.prepare_request(data);
         let headers_json = Self::headers_to_json(&data.headers);
         let (body_json, parsed) = if data.body.is_some() {
             let (json, parsed) = self.request_body_to_json_with_fallback(&data);
@@ -477,8 +491,8 @@ where
         let query_start = Instant::now();
         let result = sqlx::query(
             r#"
-            INSERT INTO http_requests (instance_id, correlation_id, timestamp, method, uri, headers, body, body_parsed, trace_id, span_id)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            INSERT INTO http_requests (instance_id, correlation_id, timestamp, method, uri, headers, body, body_parsed, trace_id, span_id, subject_id)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
             "#,
         )
         .bind(self.instance_id)
@@ -491,6 +505,7 @@ where
         .bind(parsed)
         .bind(&data.trace_id)
         .bind(&data.span_id)
+        .bind(subject_id)
         .execute(self.pool.write())
         .await;
         let query_duration = query_start.elapsed();
@@ -515,6 +530,13 @@ where
 
     #[instrument(name = "outlet.handle_response", skip(self, request_data, response_data), fields(correlation_id = %request_data.correlation_id))]
     async fn handle_response(&self, request_data: RequestData, response_data: ResponseData) {
+        let PreparedResponse {
+            request: request_data,
+            response: response_data,
+            subject_id,
+        } = self
+            .capture_policy
+            .prepare_response(request_data, response_data);
         let headers_json = Self::headers_to_json(&response_data.headers);
         let (body_json, parsed) = if response_data.body.is_some() {
             let (json, parsed) =
@@ -531,8 +553,8 @@ where
         let query_start = Instant::now();
         let result = sqlx::query(
             r#"
-            INSERT INTO http_responses (instance_id, correlation_id, timestamp, status_code, headers, body, body_parsed, duration_to_first_byte_ms, duration_ms)
-            SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9
+            INSERT INTO http_responses (instance_id, correlation_id, timestamp, status_code, headers, body, body_parsed, duration_to_first_byte_ms, duration_ms, subject_id)
+            SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10
             WHERE EXISTS (SELECT 1 FROM http_requests WHERE instance_id = $1 AND correlation_id = $2)
             "#,
         )
@@ -545,6 +567,7 @@ where
         .bind(parsed)
         .bind(duration_to_first_byte_ms)
         .bind(duration_ms)
+        .bind(subject_id)
         .execute(self.pool.write())
         .await;
         let query_duration = query_start.elapsed();
@@ -591,8 +614,11 @@ where
         let mut body_parsed_col = Vec::with_capacity(len);
         let mut trace_ids: Vec<Option<String>> = Vec::with_capacity(len);
         let mut span_ids: Vec<Option<String>> = Vec::with_capacity(len);
+        let mut subject_ids: Vec<Option<String>> = Vec::with_capacity(len);
 
         for data in batch {
+            let PreparedRequest { data, subject_id } =
+                self.capture_policy.prepare_request(data.clone());
             instance_ids.push(self.instance_id);
             correlation_ids.push(data.correlation_id as i64);
             timestamps.push(DateTime::<Utc>::from(data.timestamp));
@@ -601,7 +627,7 @@ where
             headers_col.push(Self::headers_to_json(&data.headers));
 
             let (body_json, parsed) = if data.body.is_some() {
-                let (json, parsed) = self.request_body_to_json_with_fallback(data);
+                let (json, parsed) = self.request_body_to_json_with_fallback(&data);
                 (Some(json), parsed)
             } else {
                 (None, false)
@@ -610,13 +636,14 @@ where
             body_parsed_col.push(parsed);
             trace_ids.push(data.trace_id.clone());
             span_ids.push(data.span_id.clone());
+            subject_ids.push(subject_id);
         }
 
         let query_start = Instant::now();
         let result = sqlx::query(
             r#"
-            INSERT INTO http_requests (instance_id, correlation_id, timestamp, method, uri, headers, body, body_parsed, trace_id, span_id)
-            SELECT * FROM UNNEST($1::uuid[], $2::bigint[], $3::timestamptz[], $4::varchar[], $5::text[], $6::jsonb[], $7::jsonb[], $8::boolean[], $9::varchar[], $10::varchar[])
+            INSERT INTO http_requests (instance_id, correlation_id, timestamp, method, uri, headers, body, body_parsed, trace_id, span_id, subject_id)
+            SELECT * FROM UNNEST($1::uuid[], $2::bigint[], $3::timestamptz[], $4::varchar[], $5::text[], $6::jsonb[], $7::jsonb[], $8::boolean[], $9::varchar[], $10::varchar[], $11::text[])
             "#,
         )
         .bind(&instance_ids)
@@ -629,6 +656,7 @@ where
         .bind(&body_parsed_col)
         .bind(&trace_ids)
         .bind(&span_ids)
+        .bind(&subject_ids)
         .execute(self.pool.write())
         .await;
         let query_duration = query_start.elapsed();
@@ -666,8 +694,16 @@ where
         let mut body_parsed_col = Vec::with_capacity(len);
         let mut duration_to_first_byte_ms_col = Vec::with_capacity(len);
         let mut duration_ms_col = Vec::with_capacity(len);
+        let mut subject_ids: Vec<Option<String>> = Vec::with_capacity(len);
 
         for (request_data, response_data) in batch {
+            let PreparedResponse {
+                request: request_data,
+                response: response_data,
+                subject_id,
+            } = self
+                .capture_policy
+                .prepare_response(request_data.clone(), response_data.clone());
             instance_ids.push(self.instance_id);
             correlation_ids.push(request_data.correlation_id as i64);
             timestamps.push(DateTime::<Utc>::from(response_data.timestamp));
@@ -676,7 +712,7 @@ where
 
             let (body_json, parsed) = if response_data.body.is_some() {
                 let (json, parsed) =
-                    self.response_body_to_json_with_fallback(request_data, response_data);
+                    self.response_body_to_json_with_fallback(&request_data, &response_data);
                 (Some(json), parsed)
             } else {
                 (None, false)
@@ -686,13 +722,14 @@ where
             duration_to_first_byte_ms_col
                 .push(response_data.duration_to_first_byte.as_millis() as i64);
             duration_ms_col.push(response_data.duration.as_millis() as i64);
+            subject_ids.push(subject_id);
         }
 
         let query_start = Instant::now();
         let result = sqlx::query(
             r#"
-            INSERT INTO http_responses (instance_id, correlation_id, timestamp, status_code, headers, body, body_parsed, duration_to_first_byte_ms, duration_ms)
-            SELECT * FROM UNNEST($1::uuid[], $2::bigint[], $3::timestamptz[], $4::int[], $5::jsonb[], $6::jsonb[], $7::boolean[], $8::bigint[], $9::bigint[])
+            INSERT INTO http_responses (instance_id, correlation_id, timestamp, status_code, headers, body, body_parsed, duration_to_first_byte_ms, duration_ms, subject_id)
+            SELECT * FROM UNNEST($1::uuid[], $2::bigint[], $3::timestamptz[], $4::int[], $5::jsonb[], $6::jsonb[], $7::boolean[], $8::bigint[], $9::bigint[], $10::text[])
             "#,
         )
         .bind(&instance_ids)
@@ -704,6 +741,7 @@ where
         .bind(&body_parsed_col)
         .bind(&duration_to_first_byte_ms_col)
         .bind(&duration_ms_col)
+        .bind(&subject_ids)
         .execute(self.pool.write())
         .await;
         let query_duration = query_start.elapsed();
@@ -792,6 +830,271 @@ mod tests {
             duration: Duration::from_millis(150),
             correlation_id: 0,
             extensions: Default::default(),
+        }
+    }
+
+    fn request_with_headers(
+        headers: impl IntoIterator<Item = (&'static str, &'static str)>,
+    ) -> RequestData {
+        let mut request = create_test_request_data();
+        request.headers = headers
+            .into_iter()
+            .map(|(name, value)| (name.to_owned(), vec![Bytes::from_static(value.as_bytes())]))
+            .collect();
+        request
+    }
+
+    fn response_with_headers(
+        headers: impl IntoIterator<Item = (&'static str, &'static str)>,
+    ) -> ResponseData {
+        let mut response = create_test_response_data();
+        response.headers = headers
+            .into_iter()
+            .map(|(name, value)| (name.to_owned(), vec![Bytes::from_static(value.as_bytes())]))
+            .collect();
+        response
+    }
+
+    #[sqlx::test]
+    async fn capture_policy_sanitises_request_columns_and_serializer_input(pool: PgPool) {
+        crate::migrator().run(&pool).await.unwrap();
+        let handler = PostgresHandler::<_, Value, Value>::from_pool(pool.clone())
+            .await
+            .unwrap()
+            .with_request_serializer(|request| {
+                Ok(serde_json::json!({
+                    "has_authorization": request.headers.contains_key("authorization"),
+                    "has_content_type": request.headers.contains_key("content-type"),
+                }))
+            })
+            .with_capture_policy(
+                CapturePolicy::allow_headers(["content-type"])
+                    .unwrap()
+                    .with_subject_header("x-capture-subject")
+                    .unwrap(),
+            );
+
+        handler
+            .handle_request(request_with_headers([
+                ("authorization", "Bearer must-not-persist"),
+                ("x-capture-subject", "subject-7"),
+                ("content-type", "application/json"),
+            ]))
+            .await;
+
+        let (headers, body, subject_id): (Value, Value, Option<String>) =
+            sqlx::query_as("SELECT headers, body, subject_id FROM http_requests LIMIT 1")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            headers,
+            serde_json::json!({"content-type":"application/json"})
+        );
+        assert_eq!(body["has_authorization"], false);
+        assert_eq!(body["has_content_type"], true);
+        assert_eq!(subject_id.as_deref(), Some("subject-7"));
+        assert!(!body.to_string().contains("must-not-persist"));
+
+        let pairs = handler
+            .repository()
+            .query_by_subject_id("subject-7", RequestFilter::default())
+            .await
+            .unwrap();
+        assert_eq!(pairs.len(), 1);
+        let non_matching = handler
+            .repository()
+            .query_by_subject_id("subject-other", RequestFilter::default())
+            .await
+            .unwrap();
+        assert!(non_matching.is_empty());
+    }
+
+    #[sqlx::test]
+    async fn capture_policy_sanitises_response_and_both_serializer_inputs(pool: PgPool) {
+        crate::migrator().run(&pool).await.unwrap();
+        let handler = PostgresHandler::<_, Value, Value>::from_pool(pool.clone())
+            .await
+            .unwrap()
+            .with_response_serializer(|request, response| {
+                Ok(serde_json::json!({
+                    "request_has_authorization": request.headers.contains_key("authorization"),
+                    "request_has_content_type": request.headers.contains_key("content-type"),
+                    "response_has_set_cookie": response.headers.contains_key("set-cookie"),
+                    "response_has_cache_control": response.headers.contains_key("cache-control"),
+                }))
+            })
+            .with_capture_policy(
+                CapturePolicy::all()
+                    .with_request_headers(["content-type"])
+                    .unwrap()
+                    .with_response_headers(["cache-control"])
+                    .unwrap()
+                    .with_subject_header("x-capture-subject")
+                    .unwrap(),
+            );
+        let mut request = request_with_headers([
+            ("authorization", "Bearer must-not-persist"),
+            ("x-capture-subject", "subject-8"),
+            ("content-type", "application/json"),
+        ]);
+        let mut response = response_with_headers([
+            ("set-cookie", "session=must-not-persist"),
+            ("cache-control", "no-store"),
+        ]);
+        request.correlation_id = 8;
+        response.correlation_id = 8;
+
+        handler.handle_request(request.clone()).await;
+        handler.handle_response(request, response).await;
+
+        let (headers, body, subject_id): (Value, Value, Option<String>) =
+            sqlx::query_as("SELECT headers, body, subject_id FROM http_responses LIMIT 1")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(headers, serde_json::json!({"cache-control":"no-store"}));
+        assert_eq!(body["request_has_authorization"], false);
+        assert_eq!(body["request_has_content_type"], true);
+        assert_eq!(body["response_has_set_cookie"], false);
+        assert_eq!(body["response_has_cache_control"], true);
+        assert_eq!(subject_id.as_deref(), Some("subject-8"));
+        assert!(!body.to_string().contains("must-not-persist"));
+
+        let pairs = handler
+            .repository()
+            .query_by_subject_id("subject-8", RequestFilter::default())
+            .await
+            .unwrap();
+        assert_eq!(pairs.len(), 1);
+        assert!(pairs[0].response.is_some());
+    }
+
+    #[sqlx::test]
+    async fn batch_capture_policy_sanitises_requests_and_attributes_subjects(pool: PgPool) {
+        crate::migrator().run(&pool).await.unwrap();
+        let handler = PostgresHandler::<_, Value, Value>::from_pool(pool.clone())
+            .await
+            .unwrap()
+            .with_request_serializer(|request| {
+                Ok(serde_json::json!({
+                    "has_authorization": request.headers.contains_key("authorization"),
+                    "has_content_type": request.headers.contains_key("content-type"),
+                }))
+            })
+            .with_capture_policy(
+                CapturePolicy::allow_headers(["content-type"])
+                    .unwrap()
+                    .with_subject_header("x-capture-subject")
+                    .unwrap(),
+            );
+        let mut first = request_with_headers([
+            ("authorization", "Bearer first-secret"),
+            ("x-capture-subject", "subject-1"),
+            ("content-type", "application/json"),
+        ]);
+        let mut second = request_with_headers([
+            ("authorization", "Bearer second-secret"),
+            ("x-capture-subject", "subject-2"),
+            ("content-type", "application/json"),
+        ]);
+        first.correlation_id = 101;
+        second.correlation_id = 102;
+
+        handler.handle_request_batch(&[first, second]).await;
+
+        let rows: Vec<(i64, Value, Value, Option<String>)> = sqlx::query_as(
+            "SELECT correlation_id, headers, body, subject_id FROM http_requests ORDER BY correlation_id",
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(rows.len(), 2);
+        for (index, (correlation_id, headers, body, subject_id)) in rows.iter().enumerate() {
+            assert_eq!(*correlation_id, 101 + index as i64);
+            assert_eq!(
+                headers,
+                &serde_json::json!({"content-type":"application/json"})
+            );
+            assert_eq!(body["has_authorization"], false);
+            assert_eq!(body["has_content_type"], true);
+            assert_eq!(
+                subject_id.as_deref(),
+                Some(format!("subject-{}", index + 1).as_str())
+            );
+        }
+    }
+
+    #[sqlx::test]
+    async fn batch_capture_policy_sanitises_responses_and_attributes_subjects(pool: PgPool) {
+        crate::migrator().run(&pool).await.unwrap();
+        let handler = PostgresHandler::<_, Value, Value>::from_pool(pool.clone())
+            .await
+            .unwrap()
+            .with_response_serializer(|request, response| {
+                Ok(serde_json::json!({
+                    "request_has_authorization": request.headers.contains_key("authorization"),
+                    "response_has_set_cookie": response.headers.contains_key("set-cookie"),
+                    "response_has_cache_control": response.headers.contains_key("cache-control"),
+                }))
+            })
+            .with_capture_policy(
+                CapturePolicy::all()
+                    .with_request_headers(["content-type"])
+                    .unwrap()
+                    .with_response_headers(["cache-control"])
+                    .unwrap()
+                    .with_subject_header("x-capture-subject")
+                    .unwrap(),
+            );
+        let mut first_request = request_with_headers([
+            ("authorization", "Bearer first-secret"),
+            ("x-capture-subject", "subject-1"),
+            ("content-type", "application/json"),
+        ]);
+        let mut second_request = request_with_headers([
+            ("authorization", "Bearer second-secret"),
+            ("x-capture-subject", "subject-2"),
+            ("content-type", "application/json"),
+        ]);
+        let mut first_response = response_with_headers([
+            ("set-cookie", "first-secret"),
+            ("cache-control", "no-store"),
+        ]);
+        let mut second_response = response_with_headers([
+            ("set-cookie", "second-secret"),
+            ("cache-control", "no-store"),
+        ]);
+        first_request.correlation_id = 201;
+        first_response.correlation_id = 201;
+        second_request.correlation_id = 202;
+        second_response.correlation_id = 202;
+        let requests = [first_request.clone(), second_request.clone()];
+        let pairs = [
+            (first_request, first_response),
+            (second_request, second_response),
+        ];
+
+        handler.handle_request_batch(&requests).await;
+        handler.handle_response_batch(&pairs).await;
+
+        let rows: Vec<(i64, Value, Value, Option<String>)> = sqlx::query_as(
+            "SELECT correlation_id, headers, body, subject_id FROM http_responses ORDER BY correlation_id",
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(rows.len(), 2);
+        for (index, (correlation_id, headers, body, subject_id)) in rows.iter().enumerate() {
+            assert_eq!(*correlation_id, 201 + index as i64);
+            assert_eq!(headers, &serde_json::json!({"cache-control":"no-store"}));
+            assert_eq!(body["request_has_authorization"], false);
+            assert_eq!(body["response_has_set_cookie"], false);
+            assert_eq!(body["response_has_cache_control"], true);
+            assert_eq!(
+                subject_id.as_deref(),
+                Some(format!("subject-{}", index + 1).as_str())
+            );
         }
     }
 

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -67,6 +67,13 @@ pub struct RequestFilter {
 
 impl RequestFilter {
     pub fn build_query(&self) -> QueryBuilder<'_, sqlx::Postgres> {
+        self.build_query_with_subject(None)
+    }
+
+    fn build_query_with_subject<'a>(
+        &'a self,
+        subject_id: Option<&'a str>,
+    ) -> QueryBuilder<'a, sqlx::Postgres> {
         let mut query = QueryBuilder::new(
             r#"
             SELECT 
@@ -97,6 +104,17 @@ impl RequestFilter {
             }
             query.push("r.correlation_id = ");
             query.push_bind(correlation_id);
+        }
+
+        if let Some(subject_id) = subject_id {
+            if where_added {
+                query.push(" AND ");
+            } else {
+                query.push(" WHERE ");
+                where_added = true;
+            }
+            query.push("r.subject_id = ");
+            query.push_bind(subject_id);
         }
 
         if let Some(method) = &self.method {
@@ -267,8 +285,26 @@ where
         &self,
         filter: RequestFilter,
     ) -> Result<Vec<RequestResponsePair<TReq, TRes>>, PostgresHandlerError> {
+        self.query_with_optional_subject(filter, None).await
+    }
+
+    /// Query request/response pairs attributed to an exact opaque subject.
+    pub async fn query_by_subject_id(
+        &self,
+        subject_id: &str,
+        filter: RequestFilter,
+    ) -> Result<Vec<RequestResponsePair<TReq, TRes>>, PostgresHandlerError> {
+        self.query_with_optional_subject(filter, Some(subject_id))
+            .await
+    }
+
+    async fn query_with_optional_subject(
+        &self,
+        filter: RequestFilter,
+        subject_id: Option<&str>,
+    ) -> Result<Vec<RequestResponsePair<TReq, TRes>>, PostgresHandlerError> {
         let rows = filter
-            .build_query()
+            .build_query_with_subject(subject_id)
             .build()
             .fetch_all(self.pool.read())
             .await
@@ -403,6 +439,16 @@ mod tests {
 
         validate_sql(sql).unwrap();
         assert!(sql.contains("WHERE r.correlation_id = $1"));
+    }
+
+    #[test]
+    fn test_subject_id_filter() {
+        let filter = RequestFilter::default();
+        let query = filter.build_query_with_subject(Some("subject-1"));
+        let sql = query.sql();
+
+        validate_sql(sql).unwrap();
+        assert!(sql.contains("WHERE r.subject_id = $1"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add configurable request and response header allowlists before serialization and persistence
- add optional opaque subject attribution with exact repository lookup
- apply identical behavior to single and batch writes while preserving the default capture behavior
- add an additive nullable-column migration without building deployment-specific indexes

## Safety and compatibility

- filtered headers are removed from both stored header JSON and custom serializer inputs
- subject carriers are suppressed unless explicitly allowlisted
- invalid, empty, or ambiguous subjects are not attributed
- existing public request, response, and filter structs remain source-compatible
- configuration contains no application-specific headers or retention values

## Verification

- 46 unit and PostgreSQL integration tests
- 5 doctests
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo doc --no-deps
- upgrade test from the prior migration set with existing partitioned rows